### PR TITLE
Remove "cache_class_" prefix from bin

### DIFF
--- a/src/Heisencache/Config.php
+++ b/src/Heisencache/Config.php
@@ -142,6 +142,7 @@ class Config {
 
     foreach ($this->conf as $bin => $class) {
       if (!strncmp($bin, self::VAR_CACHE_CLASS_PREFIX, $len)) {
+        $bin = substr($bin, $len);
         $this->visible_bins[$bin] = static::CACHE_CLASS;
         $this->actual_bins[$bin] = new $class($bin);
       }


### PR DESCRIPTION
We found that all caches use default cache class. The reason is that `cache_class_` prefix is not removed from bin name in `\OSInet\Heisencache\Config::overrideCacheClasses()`
